### PR TITLE
Support for shared configuration in pipelines

### DIFF
--- a/codefresh/provider_test.go
+++ b/codefresh/provider_test.go
@@ -1,24 +1,24 @@
 package codefresh
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var testAccProvider *schema.Provider
-var testAccProviders map[string]terraform.ResourceProvider
+var testAccProviders map[string]*schema.Provider
 
 func init() {
-	testAccProvider = Provider().(*schema.Provider)
-	testAccProviders = map[string]terraform.ResourceProvider{
+	testAccProvider = Provider()
+	testAccProviders = map[string]*schema.Provider{
 		"codefresh": testAccProvider,
 	}
 }
 
 func TestProvider(t *testing.T) {
-	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }

--- a/codefresh/resource_pipeline.go
+++ b/codefresh/resource_pipeline.go
@@ -2,9 +2,10 @@ package codefresh
 
 import (
 	"fmt"
+	"strings"
+
 	cfClient "github.com/codefresh-io/terraform-provider-codefresh/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"strings"
 )
 
 func resourcePipeline() *schema.Resource {
@@ -28,7 +29,6 @@ func resourcePipeline() *schema.Resource {
 			"project_id": {
 				Type:     schema.TypeString,
 				Computed: true,
-
 			},
 			"revision": {
 				Type:     schema.TypeInt,
@@ -156,6 +156,13 @@ func resourcePipeline() *schema.Resource {
 										},
 									},
 								},
+							},
+						},
+						"contexts": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
 							},
 						},
 						"runtime_environment": {
@@ -316,6 +323,8 @@ func flattenSpec(spec cfClient.Spec) []interface{} {
 
 	m["priority"] = spec.Priority
 
+	m["contexts"] = spec.Contexts
+
 	res = append(res, m)
 	return res
 }
@@ -406,6 +415,9 @@ func mapResourceToPipeline(d *schema.ResourceData) *cfClient.Pipeline {
 			DindStorage: d.Get("spec.0.runtime_environment.0.dind_storage").(string),
 		}
 	}
+
+	contexts := d.Get("spec.0.contexts").([]interface{})
+	pipeline.Spec.Contexts = contexts
 
 	variables := d.Get("spec.0.variables").(map[string]interface{})
 	pipeline.SetVariables(variables)

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -36,6 +36,11 @@ resource "codefresh_pipeline" "test" {
       context     = "git"
     }
 
+    contexts = [
+      "context1-name",
+      "context2-name",
+    ]
+
     trigger {
       branch_regex  = "/.*/gi"
       context       = "git"
@@ -94,6 +99,7 @@ resource "codefresh_pipeline" "test" {
 - `trigger` - (Optional) A collection of `trigger` blocks as documented below. Triggers [documentation](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/triggers/git-triggers/).
 - `spec_template` - (Optional) A collection of `spec_template` blocks as documented below.
 - `runtime_environment` - (Optional) A collection of `runtime_environment` blocks as documented below.
+- `contexts` - (Optional) A list of strings representing the contexts ([shared_configuration](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/shared-configuration/)) to be configured for the pipeline
 
 ---
 

--- a/examples/pipelines.md
+++ b/examples/pipelines.md
@@ -42,6 +42,11 @@ resource "codefresh_pipeline" "test" {
       context     = "git"
     }
 
+    contexts = [
+      "context1-name",
+      "context2-name",
+    ]
+
     trigger {
       branch_regex  = "/.*/gi"
       context       = "git"


### PR DESCRIPTION
This change should allow to set contexts in a pipeline resource. I've compiled a version of the provider from my branch and tested it with a secret context and a config context. The pipeline created loads correctly the contexts.

I've updated the test files, however, I couldn't get the test working locally since I'm getting this error (NOTE: I get the below even from master branch without any change, so this is not related to the changes introduced in this PR):
```
 testing_new.go:106: terraform failed: exit status 1
        stderr:
        Error: Failed to instantiate provider "codefresh" to obtain schema: Unrecognized remote plugin message: 
```
I'm happy to perform further validations and have the test cases validated on my end, but I might need some guidance on how to resolve the above.

Closes #15 