### PR TITLE
Add pull_request_allow_fork_events to trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform provider for Codefresh
 
-This provider was initialized by [LightStep](https://lightstep.com/) and will be maintained as the official Terraform provider for Codefresh.  
+This provider was initialized by [LightStep](https://lightstep.com/) and will be maintained as the official Terraform provider for Codefresh.
 
 The provider is still under development, and can be used as a terraform [third-party plugin](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) only.
 
@@ -18,7 +18,7 @@ Download and extract terraform-provider-codefresh from [releases](https://github
 go build -o terraform-provider-codefresh
 ```
 
-## Using the Provicer
+## Using the Provider
 
 Compile or take from the [Releases](https://github.com/codefresh-contrib/terraform-provider-codefresh/releases) `terraform-provider-codefresh` binary and place it locally according the Terraform plugins [documentation](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins).
 
@@ -43,7 +43,7 @@ terraform {
       versions = ["0.1.0"]
       source = "codefresh.io/app/codefresh"
     }
-  }  
+  }
 }
 ```
 
@@ -52,7 +52,7 @@ terraform {
 
 ## [Examples](./examples)
 
-## To configure codefresh provider:
+## To configure Codefresh provider:
 
 ```hcl
 provider "codefresh" {

--- a/client/pipeline.go
+++ b/client/pipeline.go
@@ -35,17 +35,18 @@ type SpecTemplate struct {
 }
 
 type Trigger struct {
-	Name              string     `json:"name,omitempty"`
-	Description       string     `json:"description,omitempty"`
-	Type              string     `json:"type,omitempty"`
-	Repo              string     `json:"repo,omitempty"`
-	Events            []string   `json:"events,omitempty"`
-	BranchRegex       string     `json:"branchRegex,omitempty"`
-	ModifiedFilesGlob string     `json:"modifiedFilesGlob,omitempty"`
-	Provider          string     `json:"provider,omitempty"`
-	Disabled          bool       `json:"disabled,omitempty"`
-	Context           string     `json:"context,omitempty"`
-	Variables         []Variable `json:"variables,omitempty"`
+	Name                       string     `json:"name,omitempty"`
+	Description                string     `json:"description,omitempty"`
+	Type                       string     `json:"type,omitempty"`
+	Repo                       string     `json:"repo,omitempty"`
+	Events                     []string   `json:"events,omitempty"`
+	BranchRegex                string     `json:"branchRegex,omitempty"`
+	ModifiedFilesGlob          string     `json:"modifiedFilesGlob,omitempty"`
+	Provider                   string     `json:"provider,omitempty"`
+	Disabled                   bool       `json:"disabled,omitempty"`
+	PullRequestAllowForkEvents bool       `json:"pullRequestAllowForkEvents,omitempty"`
+	Context                    string     `json:"context,omitempty"`
+	Variables                  []Variable `json:"variables,omitempty"`
 }
 
 type RuntimeEnvironment struct {

--- a/codefresh/resource_pipeline.go
+++ b/codefresh/resource_pipeline.go
@@ -143,6 +143,11 @@ func resourcePipeline() *schema.Resource {
 										Optional: true,
 										Default:  false,
 									},
+									"pull_request_allow_fork_events": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
 									"context": {
 										Type:     schema.TypeString,
 										Optional: true,
@@ -363,6 +368,7 @@ func flattenTriggers(triggers []cfClient.Trigger) []map[string]interface{} {
 		m["branch_regex"] = trigger.BranchRegex
 		m["modified_files_glob"] = trigger.ModifiedFilesGlob
 		m["disabled"] = trigger.Disabled
+		m["pull_request_allow_fork_events"] = trigger.PullRequestAllowForkEvents
 		m["provider"] = trigger.Provider
 		m["type"] = trigger.Type
 		m["events"] = trigger.Events
@@ -427,16 +433,17 @@ func mapResourceToPipeline(d *schema.ResourceData) *cfClient.Pipeline {
 		events := d.Get(fmt.Sprintf("spec.0.trigger.%v.events", idx)).([]interface{})
 
 		codefreshTrigger := cfClient.Trigger{
-			Name:              d.Get(fmt.Sprintf("spec.0.trigger.%v.name", idx)).(string),
-			Description:       d.Get(fmt.Sprintf("spec.0.trigger.%v.description", idx)).(string),
-			Type:              d.Get(fmt.Sprintf("spec.0.trigger.%v.type", idx)).(string),
-			Repo:              d.Get(fmt.Sprintf("spec.0.trigger.%v.repo", idx)).(string),
-			BranchRegex:       d.Get(fmt.Sprintf("spec.0.trigger.%v.branch_regex", idx)).(string),
-			ModifiedFilesGlob: d.Get(fmt.Sprintf("spec.0.trigger.%v.modified_files_glob", idx)).(string),
-			Provider:          d.Get(fmt.Sprintf("spec.0.trigger.%v.provider", idx)).(string),
-			Disabled:          d.Get(fmt.Sprintf("spec.0.trigger.%v.disabled", idx)).(bool),
-			Context:           d.Get(fmt.Sprintf("spec.0.trigger.%v.context", idx)).(string),
-			Events:            convertStringArr(events),
+			Name:                       d.Get(fmt.Sprintf("spec.0.trigger.%v.name", idx)).(string),
+			Description:                d.Get(fmt.Sprintf("spec.0.trigger.%v.description", idx)).(string),
+			Type:                       d.Get(fmt.Sprintf("spec.0.trigger.%v.type", idx)).(string),
+			Repo:                       d.Get(fmt.Sprintf("spec.0.trigger.%v.repo", idx)).(string),
+			BranchRegex:                d.Get(fmt.Sprintf("spec.0.trigger.%v.branch_regex", idx)).(string),
+			ModifiedFilesGlob:          d.Get(fmt.Sprintf("spec.0.trigger.%v.modified_files_glob", idx)).(string),
+			Provider:                   d.Get(fmt.Sprintf("spec.0.trigger.%v.provider", idx)).(string),
+			Disabled:                   d.Get(fmt.Sprintf("spec.0.trigger.%v.disabled", idx)).(bool),
+			PullRequestAllowForkEvents: d.Get(fmt.Sprintf("spec.0.trigger.%v.pull_request_allow_fork_events", idx)).(bool),
+			Context:                    d.Get(fmt.Sprintf("spec.0.trigger.%v.context", idx)).(string),
+			Events:                     convertStringArr(events),
 		}
 		variables := d.Get(fmt.Sprintf("spec.0.trigger.%v.variables", idx)).(map[string]interface{})
 		codefreshTrigger.SetVariables(variables)

--- a/codefresh/resource_pipeline_test.go
+++ b/codefresh/resource_pipeline_test.go
@@ -441,14 +441,14 @@ resource "codefresh_pipeline" "test" {
   name = "%s"
 
   spec {
-	spec_template {
-		repo        = %q
-		path        = %q
-		revision    = %q
-		context     = %q
-	}
+        spec_template {
+            repo        = %q
+            path        = %q
+            revision    = %q
+            context     = %q
+        }
 
-	trigger {
+        trigger {
         name = %q
         branch_regex = "/.*/gi"
         context = %q
@@ -473,13 +473,14 @@ resource "codefresh_pipeline" "test" {
           %q
         ]
         modified_files_glob = ""
+        pull_request_allow_fork_events = true
         provider = "github"
         repo = %q
-		type = "git"
+        type = "git"
 
-		variables = {
-			%q = %q
-		}
+        variables = {
+            %q = %q
+        }
     }
   }
 }

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -125,6 +125,8 @@ resource "codefresh_pipeline" "test" {
 - `provider` - (Optional) Default value - **github**.
 - `context` - (Optional) Codefresh Git context.
 - `variables` - (Optional) Trigger variables.
+- `disabled` - (Optional) Boolean. If false, trigger will never be activated.
+- `pull_request_allow_fork_events` - (Optional) Boolean. If this trigger is also applicable to Git forks.
 
 ---
 


### PR DESCRIPTION
pipelines trigger are missing option to set the
"pullRequestAllowForkEvents" flag

Much of the "diff" is actually whitespace changes introduced by "gofmt"