### PR TITLE
Support for specifying `spec.packId` on codefresh pipeline

### DIFF
--- a/client/pipeline.go
+++ b/client/pipeline.go
@@ -85,6 +85,7 @@ type Spec struct {
 	RuntimeEnvironment RuntimeEnvironment       `json:"runtimeEnvironment,omitempty"`
 	TerminationPolicy  []map[string]interface{} `json:"terminationPolicy,omitempty"`
 	Hooks              *Hooks                   `json:"hooks,omitempty"`
+	PackId             string                   `json:"packId,omitempty"`
 }
 
 type Steps struct {

--- a/codefresh/resource_pipeline.go
+++ b/codefresh/resource_pipeline.go
@@ -79,6 +79,10 @@ func resourcePipeline() *schema.Resource {
 							Optional: true,
 							Default:  0, // zero is unlimited
 						},
+						"pack_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"spec_template": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -563,6 +567,7 @@ func mapResourceToPipeline(d *schema.ResourceData) *cfClient.Pipeline {
 			Concurrency:        d.Get("spec.0.concurrency").(int),
 			BranchConcurrency:  d.Get("spec.0.branch_concurrency").(int),
 			TriggerConcurrency: d.Get("spec.0.trigger_concurrency").(int),
+			PackId:             d.Get("spec.0.pack_id").(string),
 		},
 	}
 

--- a/codefresh/resource_pipeline_test.go
+++ b/codefresh/resource_pipeline_test.go
@@ -57,6 +57,7 @@ func TestAccCodefreshPipeline_Concurrency(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.concurrency", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.branch_concurrency", "2"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.trigger_concurrency", "3"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.pack_id", "5cd1746617313f468d669045"),
 				),
 			},
 			{
@@ -71,6 +72,7 @@ func TestAccCodefreshPipeline_Concurrency(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.concurrency", "4"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.branch_concurrency", "5"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.trigger_concurrency", "6"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.pack_id", "6cd1746617313f468d667048"),
 				),
 			},
 		},


### PR DESCRIPTION
This PR adds a resource argument to the `codefresh_pipeline` resource that allows a `spec.packId` to be provided. This is useful to users who use the built in `SAAS runtime` environment but who want to specify the use of a `MEDIUM` or `LARGE` resource size for that runtime environment as pictured in the UI below.

Currently this is not possible and defaults to the `SMALL` resource size meaning that if changes are made to a pipeline using that resource size it will be reset to the `SMALL` resource size upon apply.

![Screen Shot 2021-04-28 at 1 48 14 PM](https://user-images.githubusercontent.com/14903000/116463810-62856680-a828-11eb-8650-e6274e4ed65a.png)

**NOTE:** I'm a new contributor to the repository and still rather new to Golang, so feel free to yell at me if I missed something important
