### PR TITLE
Update arguments for `codefresh_api_key` resource

### DIFF
--- a/docs/resources/api-key.md
+++ b/docs/resources/api-key.md
@@ -23,7 +23,7 @@ resource "random_string" "random" {
 
 resource "codefresh_api_key" "new" {
   account_id = codefresh_account.test.id
-
+  user_id = data.codefresh_account.test_account_user.user_id
   name = "tfkey_${random_string.random.result}"
 
   scopes = [
@@ -66,7 +66,8 @@ resource "codefresh_team" "team_1" {
 ## Argument Reference
 
 - `name` - (Required) The display name for the API key.
-- `account_id` - (Required) The ID of account than should own the new API key.
+- `account_id` - (Required) The ID of account in which the API key will be created.
+- `user_id` - (Required) The ID of a user within the above account that will own the API key. 
 - `scopes` - (Optional) A list of access scopes, that can be targeted. The possible values:
   - `agent`
   - `agents`

--- a/docs/resources/api-key.md
+++ b/docs/resources/api-key.md
@@ -67,7 +67,7 @@ resource "codefresh_team" "team_1" {
 
 - `name` - (Required) The display name for the API key.
 - `account_id` - (Required) The ID of account in which the API key will be created.
-- `user_id` - (Required) The ID of a user within the above account that will own the API key. 
+- `user_id` - (Required) The ID of a user within the referenced `account_id` that will own the API key. 
 - `scopes` - (Optional) A list of access scopes, that can be targeted. The possible values:
   - `agent`
   - `agents`


### PR DESCRIPTION
`user_id` is a required parameter to use this resource; considering the diffs between on-prem & SaaS, I didn't feel the need to complicate the examples anymore by adding data call for user, but that is important. 

It should probably be noted that the majority of the [currently documented resources|https://registry.terraform.io/providers/codefresh-io/codefresh/latest/docs/resources/user] do not play well with self-hosted deployments.  I'm testing getting this resource working with a self-hosted deployment and will update as needed if I'm able to get a working model going.