### PR TITLE
adding details to autoselect a branch

### DIFF
--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -117,7 +117,7 @@ resource "codefresh_pipeline" "test" {
 - `location` - (Optional) Default value - **git**.
 - `repo` - (Required) The GitHub `account/repo_name`.
 - `path` - (Required) The relative path to the Codefresh pipeline file.
-- `revison` - (Required) The git revision.
+- `revison` - (Required) The git revision. Possible values: "", *name of branch*. Use "" to autoselect a branch. 
 - `context` - (Optional) The Codefresh Git [context](https://codefresh.io/docs/docs/integrations/git-providers/).
 
 ---


### PR DESCRIPTION
From the existing documentation, it is not clear how to configure pipeline.spectemplate.revision to auto select a branch, adding a bit more detail to that section in the documentation. 