### PR TITLE
Update goreleaser version to 1.6.3

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -16,7 +16,7 @@ steps:
   go_fmt:
     title: 'Formatting'
     stage: test
-    image:  goreleaser/goreleaser:v0.133
+    image:  goreleaser/goreleaser:v1.6.3
     commands:
       - go fmt
 
@@ -40,7 +40,7 @@ steps:
 
   release_binaries:
     title: Create release in Github
-    image:  goreleaser/goreleaser:v0.133
+    image:  goreleaser/goreleaser:v1.6.3
     stage: release
     environment:
       - GPG_FINGERPRINT=${{GPG_FINGERPRINT}}


### PR DESCRIPTION
Per https://goreleaser.com/deprecations/?h=darwi#builds-for-darwinarm64 you need version 1.16 or higher to build Darwin/arm64 versions. 

I have updated the version to the latest so we can release version that supports the M1 Macs