### PR TITLE
Add logic to not return error in DeleteUser when no user is found

### DIFF
--- a/client/user.go
+++ b/client/user.go
@@ -264,15 +264,15 @@ func (client *Client) DeleteUser(userName string) error {
 		Method: "DELETE",
 	}
 
-    // The API will return a 500 error if the user cannot be found	
-    // In this case the DeleteUser function should not return an error.
-    // Return error only if the body of the return message does not contain "User does not exist"
-    res, err := client.RequestAPI(&opts)
-    if err != nil {
-        if !strings.Contains(string(res), "User does not exist"){
-            return err
+        // The API will return a 500 error if the user cannot be found	
+        // In this case the DeleteUser function should not return an error.
+        // Return error only if the body of the return message does not contain "User does not exist"
+        res, err := client.RequestAPI(&opts)
+        if err != nil {
+            if !strings.Contains(string(res), "User does not exist") {
+                return err
+            }
         }
-    }
 
 	return nil
 }

--- a/client/user.go
+++ b/client/user.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"log"
+	"strings"
 )
 
 type Credentials struct {
@@ -263,10 +264,15 @@ func (client *Client) DeleteUser(userName string) error {
 		Method: "DELETE",
 	}
 
-	_, err := client.RequestAPI(&opts)
-	if err != nil {
-		return err
-	}
+    // The API will return a 500 error if the user cannot be found	
+    // In this case the DeleteUser function should not return an error.
+    // Return error only if the body of the return message does not contain "User does not exist"
+    res, err := client.RequestAPI(&opts)
+    if err != nil {
+        if !strings.Contains(string(res), "User does not exist"){
+            return err
+        }
+    }
 
 	return nil
 }


### PR DESCRIPTION
The response when a user does not exist is: something like:

{"status":500,"code":"1001","name":"INTERNAL_SERVER_ERROR","message":"could not delete user:<USERNAME>, err: \"User does not exist\"","context":{}} 
It really should be a 404, but to change the api would be a breaking-change. Instead, we should parse the response and return an err only if the RequestAPI returns an error and the response does not contain "User does not exist".