### PR TITLE
Fix: changelog-from-release

### DIFF
--- a/.github/workflows/changelog-from-release.yaml
+++ b/.github/workflows/changelog-from-release.yaml
@@ -14,5 +14,5 @@ jobs:
       - uses: rhysd/changelog-from-release/action@v3
         with:
           file: CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.CHANGELOG_FROM_RELEASE_GITHUB_TOKEN }}
           commit_summary_template: 'Update CHANGELOG.md for %s'


### PR DESCRIPTION
## What

* Fix changelog-from-release GHA

## Why

* Branch protection rules prevent this GHA from working, need GITHUB_TOKEN corresponding to user with bypass

## Notes

#39 
