### PR TITLE
Use _id when unmarshalling team members API response

### DIFF
--- a/client/team.go
+++ b/client/team.go
@@ -5,7 +5,7 @@ import (
 )
 
 type TeamUser struct {
-	ID       string `json:"id,omitempty"`
+	ID       string `json:"_id,omitempty"`
 	UserName string `json:"userName,omitempty"`
 	Email    string `json:"email,omitempty"`
 }


### PR DESCRIPTION
## What
Use _id when unmarshalling the API response for team members

## Why
Recent versions of the codefresh API do not return `id` for team members, only `_id`. See #93 for more details

## Notes

Closes #93 