### PR TITLE
Add RequiredAvailableStorage parameter to RuntimeEnvironment

### DIFF
--- a/client/pipeline.go
+++ b/client/pipeline.go
@@ -70,10 +70,11 @@ type TriggerOptions struct {
 }
 
 type RuntimeEnvironment struct {
-	Name        string `json:"name,omitempty"`
-	Memory      string `json:"memory,omitempty"`
-	CPU         string `json:"cpu,omitempty"`
-	DindStorage string `json:"dindStorage,omitempty"`
+	Name                     string `json:"name,omitempty"`
+	Memory                   string `json:"memory,omitempty"`
+	CPU                      string `json:"cpu,omitempty"`
+	DindStorage              string `json:"dindStorage,omitempty"`
+	RequiredAvailableStorage string `json:"requiredAvailableStorage,omitempty"`
 }
 
 func (t *Trigger) SetVariables(variables map[string]interface{}) {

--- a/codefresh/resource_pipeline.go
+++ b/codefresh/resource_pipeline.go
@@ -322,6 +322,11 @@ Or: <code>original_yaml_string = file("/path/to/my/codefresh.yml")</code>
 													Type:        schema.TypeString,
 													Optional:    true,
 												},
+												"required_available_storage": {
+													Description: "Minimum disk space required for build filesystem ( unit Gi is required).",
+													Type:        schema.TypeString,
+													Optional:    true,
+												},
 											},
 										},
 									},
@@ -434,6 +439,11 @@ The following table presents how to configure this block based on the options av
 									},
 									"dind_storage": {
 										Description: "The storage allocated to the runtime environment.",
+										Type:        schema.TypeString,
+										Optional:    true,
+									},
+									"required_available_storage": {
+										Description: "Minimum disk space required for build filesystem ( unit Gi is required).",
 										Type:        schema.TypeString,
 										Optional:    true,
 									},
@@ -690,10 +700,11 @@ func flattenSpecTemplate(spec cfClient.SpecTemplate) []map[string]interface{} {
 func flattenSpecRuntimeEnvironment(spec cfClient.RuntimeEnvironment) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
-			"name":         spec.Name,
-			"memory":       spec.Memory,
-			"cpu":          spec.CPU,
-			"dind_storage": spec.DindStorage,
+			"name":                       spec.Name,
+			"memory":                     spec.Memory,
+			"cpu":                        spec.CPU,
+			"dind_storage":               spec.DindStorage,
+			"required_available_storage": spec.RequiredAvailableStorage,
 		},
 	}
 }
@@ -788,10 +799,11 @@ func mapResourceToPipeline(d *schema.ResourceData) (*cfClient.Pipeline, error) {
 
 	if _, ok := d.GetOk("spec.0.runtime_environment"); ok {
 		pipeline.Spec.RuntimeEnvironment = cfClient.RuntimeEnvironment{
-			Name:        d.Get("spec.0.runtime_environment.0.name").(string),
-			Memory:      d.Get("spec.0.runtime_environment.0.memory").(string),
-			CPU:         d.Get("spec.0.runtime_environment.0.cpu").(string),
-			DindStorage: d.Get("spec.0.runtime_environment.0.dind_storage").(string),
+			Name:                     d.Get("spec.0.runtime_environment.0.name").(string),
+			Memory:                   d.Get("spec.0.runtime_environment.0.memory").(string),
+			CPU:                      d.Get("spec.0.runtime_environment.0.cpu").(string),
+			DindStorage:              d.Get("spec.0.runtime_environment.0.dind_storage").(string),
+			RequiredAvailableStorage: d.Get("spec.0.runtime_environment.0.required_available_storage").(string),
 		}
 	}
 
@@ -836,10 +848,11 @@ func mapResourceToPipeline(d *schema.ResourceData) (*cfClient.Pipeline, error) {
 		}
 		if _, ok := d.GetOk(fmt.Sprintf("spec.0.trigger.%v.runtime_environment", idx)); ok {
 			triggerRuntime := cfClient.RuntimeEnvironment{
-				Name:        d.Get(fmt.Sprintf("spec.0.trigger.%v.runtime_environment.0.name", idx)).(string),
-				Memory:      d.Get(fmt.Sprintf("spec.0.trigger.%v.runtime_environment.0.memory", idx)).(string),
-				CPU:         d.Get(fmt.Sprintf("spec.0.trigger.%v.runtime_environment.0.cpu", idx)).(string),
-				DindStorage: d.Get(fmt.Sprintf("spec.0.trigger.%v.runtime_environment.0.dind_storage", idx)).(string),
+				Name:                     d.Get(fmt.Sprintf("spec.0.trigger.%v.runtime_environment.0.name", idx)).(string),
+				Memory:                   d.Get(fmt.Sprintf("spec.0.trigger.%v.runtime_environment.0.memory", idx)).(string),
+				CPU:                      d.Get(fmt.Sprintf("spec.0.trigger.%v.runtime_environment.0.cpu", idx)).(string),
+				DindStorage:              d.Get(fmt.Sprintf("spec.0.trigger.%v.runtime_environment.0.dind_storage", idx)).(string),
+				RequiredAvailableStorage: d.Get(fmt.Sprintf("spec.0.trigger.%v.runtime_environment.0.required_available_storage", idx)).(string),
 			}
 			codefreshTrigger.RuntimeEnvironment = &triggerRuntime
 		}

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -160,6 +160,7 @@ Optional:
 - `dind_storage` (String) The storage allocated to the runtime environment.
 - `memory` (String) The memory allocated to the runtime environment.
 - `name` (String) The name of the runtime environment.
+- `required_available_storage` (String) Minimum disk space required for build filesystem ( unit Gi is required).
 
 
 <a id="nestedblock--spec--spec_template"></a>
@@ -253,6 +254,7 @@ Optional:
 - `dind_storage` (String) The storage allocated to the runtime environment.
 - `memory` (String) The memory allocated to the runtime environment.
 - `name` (String) The name of the runtime environment.
+- `required_available_storage` (String) Minimum disk space required for build filesystem ( unit Gi is required).
 
 ## Import
 


### PR DESCRIPTION
## What
- Add `RequiredAvailableStorage` to the `RuntimeEnvironment` spec

## Why
The current provider doesn't support configuration of required available storage for hybrid runtimes.

## Checklist

* [x] _I have read [CONTRIBUTING.md](https://github.com/codefresh-io/terraform-provider-codefresh/blob/master/README.md)._
* [x] _I have [allowed changes to my fork to be made](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)._
* [x] _I have added tests, assuming new tests are warranted_.
* [x] _I understand that the `/test` comment will be ignored by the CI trigger [unless it is made by a repo admin or collaborator](https://codefresh.io/docs/docs/pipelines/triggers/git-triggers/#support-for-building-pull-requests-from-forks)._