### PR TITLE
fix provider source location

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     codefresh = {
       version = "x.y.z" # Optional but recommended; replace with latest semantic version
-      source = "codefresh.io/codefresh"
+      source = "codefresh-io/codefresh"
     }
   }
 }


### PR DESCRIPTION
## What
Changed:

```
source = "codefresh.io/codefresh"
```

To:
```
source = "codefresh-io/codefresh"
```


## Why
Dots are not accepted:

```
│ Error: Invalid provider namespace
│
│   on _providers.tf line 8, in terraform:
│    8:       source = "codefresh.io/codefresh"
│
│ Invalid provider namespace "" in source "codefresh.io/codefresh": dots are not 
│ allowed"
```

## Notes
<!-- Add any notes here -->

## Checklist

* [X] _I have read [CONTRIBUTING.md](https://github.com/codefresh-io/terraform-provider-codefresh/blob/master/CONTRIBUTING.md)._
* [X] _I have [allowed changes to my fork to be made](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)._
* [X] _I have added tests, assuming new tests are warranted_.
* [X] _I understand that the `/test` comment will be ignored by the CI trigger [unless it is made by a repo admin or collaborator](https://codefresh.io/docs/docs/pipelines/triggers/git-triggers/#support-for-building-pull-requests-from-forks)._
