### PR TITLE
Add inline cron triggers to `codefresh_pipeline`

### DIFF
--- a/client/pipeline.go
+++ b/client/pipeline.go
@@ -71,8 +71,6 @@ type CronTrigger struct {
 	Branch             string              `json:"branch,omitempty"`
 	Disabled           bool                `json:"disabled,omitempty"`
 	Options            *TriggerOptions     `json:"options,omitempty"`
-	CommitStatusTitle  string              `json:"commitStatusTitle,omitempty"`
-	Context            string              `json:"context,omitempty"`
 	RuntimeEnvironment *RuntimeEnvironment `json:"runtimeEnvironment,omitempty"`
 	Variables          []Variable          `json:"variables,omitempty"`
 }

--- a/client/pipeline.go
+++ b/client/pipeline.go
@@ -62,6 +62,21 @@ type Trigger struct {
 	Variables                    []Variable          `json:"variables,omitempty"`
 }
 
+type CronTrigger struct {
+	Name               string              `json:"name,omitempty"`
+	Type               string              `json:"type,omitempty"`
+	Expression         string              `json:"expression,omitempty"`
+	Message            string              `json:"message,omitempty"`
+	GitTriggerId       string              `json:"gitTriggerId,omitempty"`
+	Branch             string              `json:"branch,omitempty"`
+	Disabled           bool                `json:"disabled,omitempty"`
+	Options            *TriggerOptions     `json:"options,omitempty"`
+	CommitStatusTitle  string              `json:"commitStatusTitle,omitempty"`
+	Context            string              `json:"context,omitempty"`
+	RuntimeEnvironment *RuntimeEnvironment `json:"runtimeEnvironment,omitempty"`
+	Variables          []Variable          `json:"variables,omitempty"`
+}
+
 type TriggerOptions struct {
 	NoCache             bool `json:"noCache,omitempty"`
 	NoCfCache           bool `json:"noCfCache,omitempty"`
@@ -83,10 +98,17 @@ func (t *Trigger) SetVariables(variables map[string]interface{}) {
 	}
 }
 
+func (t *CronTrigger) SetVariables(variables map[string]interface{}) {
+	for key, value := range variables {
+		t.Variables = append(t.Variables, Variable{Key: key, Value: value.(string)})
+	}
+}
+
 type Spec struct {
 	Variables                []Variable               `json:"variables,omitempty"`
 	SpecTemplate             *SpecTemplate            `json:"specTemplate,omitempty"`
 	Triggers                 []Trigger                `json:"triggers,omitempty"`
+	CronTriggers             []CronTrigger            `json:"cronTriggers,omitempty"`
 	Priority                 int                      `json:"priority,omitempty"`
 	Concurrency              int                      `json:"concurrency,omitempty"`
 	BranchConcurrency        int                      `json:"branchConcurrency,omitempty"`

--- a/codefresh/resource_pipeline.go
+++ b/codefresh/resource_pipeline.go
@@ -461,11 +461,6 @@ Or: <code>original_yaml_string = file("/path/to/my/codefresh.yml")</code>
 											},
 										},
 									},
-									"commit_status_title": {
-										Description: "The commit status title pushed to the git provider.",
-										Type:        schema.TypeString,
-										Optional:    true,
-									},
 									"runtime_environment": {
 										Description: "The runtime environment for the trigger.",
 										Type:        schema.TypeList,
@@ -1032,14 +1027,13 @@ func mapResourceToPipeline(d *schema.ResourceData) (*cfClient.Pipeline, error) {
 	cronTriggers := d.Get("spec.0.cronTrigger").([]interface{})
 	for idx := range cronTriggers {
 		codefreshCronTrigger := cfClient.CronTrigger{
-			Name:              d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.name", idx)).(string),
-			Type:              d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.type", idx)).(string),
-			Expression:        d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.expression", idx)).(string),
-			Message:           d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.message", idx)).(string),
-			Disabled:          d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.disabled", idx)).(bool),
-			CommitStatusTitle: d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.commit_status_title", idx)).(string),
-			GitTriggerId:      d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.git_trigger_id", idx)).(string),
-			Branch:            d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.branch", idx)).(string),
+			Name:         d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.name", idx)).(string),
+			Type:         d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.type", idx)).(string),
+			Expression:   d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.expression", idx)).(string),
+			Message:      d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.message", idx)).(string),
+			Disabled:     d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.disabled", idx)).(bool),
+			GitTriggerId: d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.git_trigger_id", idx)).(string),
+			Branch:       d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.branch", idx)).(string),
 		}
 		variables := d.Get(fmt.Sprintf("spec.0.cronTrigger.%v.variables", idx)).(map[string]interface{})
 		codefreshCronTrigger.SetVariables(variables)

--- a/codefresh/resource_pipeline.go
+++ b/codefresh/resource_pipeline.go
@@ -343,7 +343,7 @@ Or: <code>original_yaml_string = file("/path/to/my/codefresh.yml")</code>
 							},
 						},
 						"cron_trigger": {
-							Description: "The pipeline's cron triggers.",
+							Description: "The pipeline's cron triggers. Conflicts with the deprecated [codefresh_pipeline_cron_trigger](https://registry.terraform.io/providers/codefresh-io/codefresh/latest/docs/resources/pipeline_cron_trigger) resource.",
 							Type:        schema.TypeList,
 							Optional:    true,
 							Elem: &schema.Resource{
@@ -435,7 +435,7 @@ Or: <code>original_yaml_string = file("/path/to/my/codefresh.yml")</code>
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"no_cache": {
-													Description: "If true, docker layer cache is disabled",
+													Description: "If true, docker layer cache is disabled.",
 													Type:        schema.TypeBool,
 													Optional:    true,
 													Default:     false,

--- a/codefresh/resource_pipeline_cron_trigger.go
+++ b/codefresh/resource_pipeline_cron_trigger.go
@@ -16,6 +16,7 @@ import (
 
 func resourcePipelineCronTrigger() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "This resource is deprecated and will be removed in a future version of the Codefresh Terraform provider. Please use the cron_triggers attribute of the codefresh_pipeline resource instead.",
 		Description: "This resource is used to create cron-based triggers for pipeilnes.",
 		Create:      resourcePipelineCronTriggerCreate,
 		Read:        resourcePipelineCronTriggerRead,

--- a/codefresh/resource_pipeline_test.go
+++ b/codefresh/resource_pipeline_test.go
@@ -406,6 +406,121 @@ func TestAccCodefreshPipeline_Triggers(t *testing.T) {
 	})
 }
 
+func TestAccCodefreshPipeline_CronTriggers(t *testing.T) {
+	name := pipelineNamePrefix + acctest.RandString(10)
+	resourceName := "codefresh_pipeline.test"
+	var pipeline cfClient.Pipeline
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCodefreshPipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCodefreshPipelineBasicConfigCronTriggers(
+					name,
+					"codefresh-contrib/react-sample-app",
+					"./codefresh.yml",
+					"master",
+					"git",
+					"cT1",
+					"first",
+					"0 0/1 * 1/1 * *",
+					"runtime1",
+					"100mb",
+					"1cpu",
+					"1gb",
+					"1gb",
+					"cT2",
+					"second",
+					"0 0/1 * 1/1 * *",
+					"64abd1550f02a62699b10df7",
+					true,
+					true,
+					true,
+					true,
+					"MY_VAR",
+					"test",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.name", "cT1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.message", "first"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.expression", "0 0/1 * 1/1 * *"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.name", "runtime1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.memory", "100mb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.cpu", "1cpu"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.dind_storage", "1gb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.required_available_storage", "1gb"),
+
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.name", "cT2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.message", "second"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.expression", "0 0/1 * 1/1 * *"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.git_trigger_id", "64abd1550f02a62699b10df7"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.no_cache", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.no_cf_cache", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.reset_volume", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.enable_notifications", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCodefreshPipelineBasicConfigCronTriggers(
+					name,
+					"codefresh-contrib/react-sample-app",
+					"./codefresh.yml",
+					"master",
+					"git",
+					"cT1",
+					"first-1",
+					"0 0/1 * 1/1 * *",
+					"runtime2",
+					"500mb",
+					"2cpu",
+					"2gb",
+					"3gb",
+					"cT2",
+					"second",
+					"0 1/1 * 1/1 * *",
+					"00abd1550f02a62699b10df7",
+					true,
+					true,
+					false,
+					false,
+					"MY_VAR",
+					"test",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.name", "cT1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.message", "first-1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.expression", "0 0/1 * 1/1 * *"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.name", "runtime2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.memory", "500mb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.cpu", "2cpu"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.dind_storage", "2gb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.required_available_storage", "3gb"),
+
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.name", "cT2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.message", "second"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.expression", "0 1/1 * 1/1 * *"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.git_trigger_id", "00abd1550f02a62699b10df7"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.no_cache", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.no_cf_cache", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.reset_volume", "false"),
+					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.enable_notifications", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCodefreshPipeline_Revision(t *testing.T) {
 	name := pipelineNamePrefix + acctest.RandString(10)
 	resourceName := "codefresh_pipeline.test"
@@ -899,6 +1014,113 @@ resource "codefresh_pipeline" "test" {
 		trigger2VarName,
 		trigger2VarValue,
 		trigger2CommitStatusTitle)
+}
+
+func testAccCodefreshPipelineBasicConfigCronTriggers(
+	rName,
+	repo,
+	path,
+	revision,
+	context,
+	cronTrigger1Name string,
+	cronTrigger1Message string,
+	cronTrigger1Expression string,
+	cronTrigger1REName string,
+	cronTrigger1REMemory string,
+	cronTrigger1RECpu string,
+	cronTrigger1REDindStorage string,
+	cronTrigger1RERequiredAvailableStorage string,
+	cronTrigger2Name string,
+	cronTrigger2Message string,
+	cronTrigger2Expression string,
+	cronTrigger2GitTriggerId string,
+	cronTrigger2NoCache bool,
+	cronTrigger2NoCfCache bool,
+	cronTrigger2ResetVolume bool,
+	cronTrigger2EnableNotifications bool,
+	cronTrigger2VarName string,
+	cronTrigger2VarValue string,
+) string {
+	return fmt.Sprintf(`
+resource "codefresh_pipeline" "test" {
+
+  lifecycle {
+    ignore_changes = [
+      revision
+    ]
+  }
+
+  name = "%s"
+
+  spec {
+	spec_template {
+		repo        = %q
+		path        = %q
+		revision    = %q
+		context     = %q
+	}
+
+    cronTrigger {
+        name = %q
+        type = "cron"
+        branch = "main"
+        message = %q
+        expression = %q
+        disabled = true
+        runtime_environment {
+			name = %q
+			memory = %q
+			cpu = %q
+			dind_storage = %q
+			required_available_storage = %q
+		}
+    }
+
+    cronTrigger {
+        name = %q
+        type = "cron"
+        branch = "master"
+        message = %q
+        expression = %q
+        gitTriggerId = %q
+        disabled = false
+        options {
+            no_cache             = %t
+            no_cf_cache          = %t
+            reset_volume         = %t
+            enable_notifications = %t
+        }
+        variables = {
+            %q = %q
+		}
+    }
+  }
+}
+`,
+		rName,
+		repo,
+		path,
+		revision,
+		context,
+		cronTrigger1Name,
+		cronTrigger1Message,
+		cronTrigger1Expression,
+		cronTrigger1REName,
+		cronTrigger1REMemory,
+		cronTrigger1RECpu,
+		cronTrigger1REDindStorage,
+		cronTrigger1RERequiredAvailableStorage,
+		cronTrigger2Name,
+		cronTrigger2Message,
+		cronTrigger2Expression,
+		cronTrigger2GitTriggerId,
+		cronTrigger2NoCache,
+		cronTrigger2NoCfCache,
+		cronTrigger2ResetVolume,
+		cronTrigger2EnableNotifications,
+		cronTrigger2VarName,
+		cronTrigger2VarValue,
+	)
 }
 
 func testAccCodefreshPipelineBasicConfigRuntimeEnvironment(rName, repo, path, revision, context, runtimeName string) string {

--- a/codefresh/resource_pipeline_test.go
+++ b/codefresh/resource_pipeline_test.go
@@ -426,6 +426,7 @@ func TestAccCodefreshPipeline_CronTriggers(t *testing.T) {
 					"cT1",
 					"first",
 					"0 0/1 * 1/1 * *",
+					"64abd1550f02a62699b10df7",
 					"runtime1",
 					"100mb",
 					"1cpu",
@@ -444,24 +445,25 @@ func TestAccCodefreshPipeline_CronTriggers(t *testing.T) {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.name", "cT1"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.message", "first"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.expression", "0 0/1 * 1/1 * *"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.name", "runtime1"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.memory", "100mb"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.cpu", "1cpu"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.dind_storage", "1gb"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.required_available_storage", "1gb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.name", "cT1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.message", "first"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.expression", "0 0/1 * 1/1 * *"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.name", "runtime1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.memory", "100mb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.cpu", "1cpu"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.dind_storage", "1gb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.required_available_storage", "1gb"),
 
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.name", "cT2"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.message", "second"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.expression", "0 0/1 * 1/1 * *"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.git_trigger_id", "64abd1550f02a62699b10df7"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.no_cache", "true"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.no_cf_cache", "true"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.reset_volume", "true"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.enable_notifications", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.name", "cT2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.message", "second"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.expression", "0 0/1 * 1/1 * *"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.git_trigger_id", "64abd1550f02a62699b10df7"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.options.0.no_cache", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.options.0.no_cf_cache", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.options.0.reset_volume", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.options.0.enable_notifications", "true"),
 				),
 			},
 			{
@@ -479,6 +481,7 @@ func TestAccCodefreshPipeline_CronTriggers(t *testing.T) {
 					"cT1",
 					"first-1",
 					"0 0/1 * 1/1 * *",
+					"00abd1550f02a62699b10df7",
 					"runtime2",
 					"500mb",
 					"2cpu",
@@ -497,24 +500,25 @@ func TestAccCodefreshPipeline_CronTriggers(t *testing.T) {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.name", "cT1"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.message", "first-1"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.expression", "0 0/1 * 1/1 * *"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.name", "runtime2"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.memory", "500mb"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.cpu", "2cpu"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.dind_storage", "2gb"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.cronTrigger.0.runtime_environment.0.required_available_storage", "3gb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.name", "cT1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.message", "first-1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.expression", "0 0/1 * 1/1 * *"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.name", "runtime2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.memory", "500mb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.cpu", "2cpu"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.dind_storage", "2gb"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.0.runtime_environment.0.required_available_storage", "3gb"),
 
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.name", "cT2"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.message", "second"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.expression", "0 1/1 * 1/1 * *"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.0.git_trigger_id", "00abd1550f02a62699b10df7"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.no_cache", "true"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.no_cf_cache", "true"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.reset_volume", "false"),
-					resource.TestCheckResourceAttr(resourceName, "spec.1.cronTrigger.1.options.0.enable_notifications", "false"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.name", "cT2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.message", "second"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.expression", "0 1/1 * 1/1 * *"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.git_trigger_id", "00abd1550f02a62699b10df7"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.options.0.no_cache", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.options.0.no_cf_cache", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.options.0.reset_volume", "false"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.cron_trigger.1.options.0.enable_notifications", "false"),
 				),
 			},
 		},
@@ -1025,6 +1029,7 @@ func testAccCodefreshPipelineBasicConfigCronTriggers(
 	cronTrigger1Name string,
 	cronTrigger1Message string,
 	cronTrigger1Expression string,
+	cronTrigger1GitTriggerId string,
 	cronTrigger1REName string,
 	cronTrigger1REMemory string,
 	cronTrigger1RECpu string,
@@ -1060,12 +1065,13 @@ resource "codefresh_pipeline" "test" {
 		context     = %q
 	}
 
-    cronTrigger {
+    cron_trigger {
         name = %q
         type = "cron"
         branch = "main"
         message = %q
         expression = %q
+        git_trigger_id = %q
         disabled = true
         runtime_environment {
 			name = %q
@@ -1076,13 +1082,13 @@ resource "codefresh_pipeline" "test" {
 		}
     }
 
-    cronTrigger {
+    cron_trigger {
         name = %q
         type = "cron"
         branch = "master"
         message = %q
         expression = %q
-        gitTriggerId = %q
+        git_trigger_id = %q
         disabled = false
         options {
             no_cache             = %t
@@ -1105,6 +1111,7 @@ resource "codefresh_pipeline" "test" {
 		cronTrigger1Name,
 		cronTrigger1Message,
 		cronTrigger1Expression,
+		cronTrigger1GitTriggerId,
 		cronTrigger1REName,
 		cronTrigger1REMemory,
 		cronTrigger1RECpu,

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -125,6 +125,7 @@ Optional:
 - `branch_concurrency` (Number) The maximum amount of concurrent builds that may run for each branch. Zero is unlimited (default: `0`).
 - `concurrency` (Number) The maximum amount of concurrent builds. Zero is unlimited (default: `0`).
 - `contexts` (List of String) A list of strings representing the contexts ([shared_configuration](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/shared-configuration/)) to be configured for the pipeline.
+- `cron_trigger` (Block List) The pipeline's cron triggers. (see [below for nested schema](#nestedblock--spec--cron_trigger))
 - `options` (Block List, Max: 1) The options for the pipeline. (see [below for nested schema](#nestedblock--spec--options))
 - `pack_id` (String) SAAS pack (`5cd1746617313f468d669013` for Small; `5cd1746717313f468d669014` for Medium; `5cd1746817313f468d669015` for Large; `5cd1746817313f468d669017` for XL; `5cd1746817313f468d669018` for XXL).
 - `priority` (Number) Helps to organize the order of builds execution in case of reaching the concurrency limit (default: `0`).
@@ -135,6 +136,50 @@ Optional:
 - `trigger` (Block List) The pipeline's triggers (currently the only nested trigger supported is git; for other trigger types, use the `codefresh_pipeline_*_trigger` resources). (see [below for nested schema](#nestedblock--spec--trigger))
 - `trigger_concurrency` (Number) The maximum amount of concurrent builds that may run for each trigger (default: `0`).
 - `variables` (Map of String) The pipeline's variables.
+
+<a id="nestedblock--spec--cron_trigger"></a>
+### Nested Schema for `spec.cron_trigger`
+
+Required:
+
+- `expression` (String)
+- `message` (String)
+- `name` (String) The name of the cron trigger.
+
+Optional:
+
+- `branch` (String) Branch that should be passed for build triggered by this cron trigger.
+- `commit_status_title` (String) The commit status title pushed to the git provider.
+- `disabled` (Boolean) Flag to disable the trigger.
+- `git_trigger_id` (String) Related git-trigger id. Will by used to take all possible git information by branch.
+- `options` (Block List) The trigger's options. (see [below for nested schema](#nestedblock--spec--cron_trigger--options))
+- `runtime_environment` (Block List) The runtime environment for the trigger. (see [below for nested schema](#nestedblock--spec--cron_trigger--runtime_environment))
+- `type` (String) The type of the trigger (default: `cron`; see notes above).
+- `variables` (Map of String) Trigger variables.
+
+<a id="nestedblock--spec--cron_trigger--options"></a>
+### Nested Schema for `spec.cron_trigger.options`
+
+Optional:
+
+- `enable_notifications` (Boolean) If false the pipeline will not send notifications to Slack and status updates back to the Git provider.
+- `no_cache` (Boolean) If true, docker layer cache is disabled
+- `no_cf_cache` (Boolean) If true, extra Codefresh caching is disabled.
+- `reset_volume` (Boolean) If true, all files on volume will be deleted before each execution.
+
+
+<a id="nestedblock--spec--cron_trigger--runtime_environment"></a>
+### Nested Schema for `spec.cron_trigger.runtime_environment`
+
+Optional:
+
+- `cpu` (String) The CPU allocated to the runtime environment.
+- `dind_storage` (String) The storage allocated to the runtime environment.
+- `memory` (String) The memory allocated to the runtime environment.
+- `name` (String) The name of the runtime environment.
+- `required_available_storage` (String) Minimum disk space required for build filesystem ( unit Gi is required).
+
+
 
 <a id="nestedblock--spec--options"></a>
 ### Nested Schema for `spec.options`

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -149,7 +149,6 @@ Required:
 Optional:
 
 - `branch` (String) Branch that should be passed for build triggered by this cron trigger.
-- `commit_status_title` (String) The commit status title pushed to the git provider.
 - `disabled` (Boolean) Flag to disable the trigger.
 - `git_trigger_id` (String) Related git-trigger id. Will by used to take all possible git information by branch.
 - `options` (Block List) The trigger's options. (see [below for nested schema](#nestedblock--spec--cron_trigger--options))

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -11,6 +11,8 @@ The central component of the Codefresh Platform. Pipelines are workflows that co
 
 See the [documentation](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/introduction-to-codefresh-pipelines/) for the details.
 
+~> **NOTE:** `cron_trigger` conflicts with the deprecated [codefresh_pipeline_cron_trigger](https://registry.terraform.io/providers/codefresh-io/codefresh/latest/docs/resources/pipeline_cron_trigger) resource.
+
 ## Example Usage
 
 ```hcl
@@ -125,7 +127,7 @@ Optional:
 - `branch_concurrency` (Number) The maximum amount of concurrent builds that may run for each branch. Zero is unlimited (default: `0`).
 - `concurrency` (Number) The maximum amount of concurrent builds. Zero is unlimited (default: `0`).
 - `contexts` (List of String) A list of strings representing the contexts ([shared_configuration](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/shared-configuration/)) to be configured for the pipeline.
-- `cron_trigger` (Block List) The pipeline's cron triggers. (see [below for nested schema](#nestedblock--spec--cron_trigger))
+- `cron_trigger` (Block List) The pipeline's cron triggers. Conflicts with the deprecated [codefresh_pipeline_cron_trigger](https://registry.terraform.io/providers/codefresh-io/codefresh/latest/docs/resources/pipeline_cron_trigger) resource. (see [below for nested schema](#nestedblock--spec--cron_trigger))
 - `options` (Block List, Max: 1) The options for the pipeline. (see [below for nested schema](#nestedblock--spec--options))
 - `pack_id` (String) SAAS pack (`5cd1746617313f468d669013` for Small; `5cd1746717313f468d669014` for Medium; `5cd1746817313f468d669015` for Large; `5cd1746817313f468d669017` for XL; `5cd1746817313f468d669018` for XXL).
 - `priority` (Number) Helps to organize the order of builds execution in case of reaching the concurrency limit (default: `0`).
@@ -162,7 +164,7 @@ Optional:
 Optional:
 
 - `enable_notifications` (Boolean) If false the pipeline will not send notifications to Slack and status updates back to the Git provider.
-- `no_cache` (Boolean) If true, docker layer cache is disabled
+- `no_cache` (Boolean) If true, docker layer cache is disabled.
 - `no_cf_cache` (Boolean) If true, extra Codefresh caching is disabled.
 - `reset_volume` (Boolean) If true, all files on volume will be deleted before each execution.
 

--- a/docs/resources/pipeline_cron_trigger.md
+++ b/docs/resources/pipeline_cron_trigger.md
@@ -11,6 +11,8 @@ This resource is used to create cron-based triggers for pipeilnes.
 
 See the [documentation](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/triggers/cron-triggers/).
 
+~> **DEPRECATED:** This resource is being deprecated in favor of the `cron_trigger` attribute of the [codefresh_pipeline](https://registry.terraform.io/providers/codefresh-io/codefresh/latest/docs/resources/pipeline) resource.
+
 ## Example usage
 
 ```hcl

--- a/templates/resources/pipeline.md.tmpl
+++ b/templates/resources/pipeline.md.tmpl
@@ -11,6 +11,8 @@ description: |-
 
 See the [documentation](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/introduction-to-codefresh-pipelines/) for the details.
 
+~> **NOTE:** `cron_trigger` conflicts with the deprecated [codefresh_pipeline_cron_trigger](https://registry.terraform.io/providers/codefresh-io/codefresh/latest/docs/resources/pipeline_cron_trigger) resource.
+
 ## Example Usage
 
 ```hcl

--- a/templates/resources/pipeline_cron_trigger.md.tmpl
+++ b/templates/resources/pipeline_cron_trigger.md.tmpl
@@ -11,6 +11,8 @@ description: |-
 
 See the [documentation](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/triggers/cron-triggers/).
 
+~> **DEPRECATED:** This resource is being deprecated in favor of the `cron_trigger` attribute of the [codefresh_pipeline](https://registry.terraform.io/providers/codefresh-io/codefresh/latest/docs/resources/pipeline) resource.
+
 ## Example usage
 
 ```hcl


### PR DESCRIPTION
## What

`[codefresh_pipeline]`: add `spec.cron_trigger`

## Why

New feature that supersedes [pipeline_cron_trigger](https://registry.terraform.io/providers/codefresh-io/codefresh/latest/docs/resources/pipeline_cron_trigger) added in #90 (the API used by `pipeline_cron_trigger` is limited; additional cron trigger options were recently added to the pipelines API, currently behind a feature flag)

## Notes

Will be first released as part of `0.6.0-beta-1` (pre-release)

## Checklist

* [x] _I have read [CONTRIBUTING.md](https://github.com/codefresh-io/terraform-provider-codefresh/blob/master/CONTRIBUTING.md)._
* [x] _I have [allowed changes to my fork to be made](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)._
* [x] _I have added tests, assuming new tests are warranted_.
* [x] _I understand that the `/test` comment will be ignored by the CI trigger [unless it is made by a repo admin or collaborator](https://codefresh.io/docs/docs/pipelines/triggers/git-triggers/#support-for-building-pull-requests-from-forks)._
