### PR TITLE
ci: Concurrent Provider Acceptance Tests against Different Terraform Versions 

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -22,15 +22,24 @@ steps:
   go_test:
     title: "Run tests"
     stage: test
-    image: goreleaser/goreleaser:v1.17.0
+    image: golang:1.18.10-alpine3.17
     environment:
       - TF_ACC="test"
+      - CGO_ENABLED=0
     commands:
+      - go install github.com/warrensbox/terraform-switcher@0.13.1308
+      - terraform-switcher --latest-stable ${TF_VERSION}
       - go test -v ./...
     retry:
       maxAttempts: 3
       delay: 5
       exponentialFactor: 2
+    matrix:
+      # The following will resolve to their latest patch version
+      environment:
+        - TF_VERSION=1.3.0
+        - TF_VERSION=1.4.0
+        - TF_VERSION=1.5.0
 
   prepare_env_vars:
     title: "Preparing environment variables..."


### PR DESCRIPTION
## What

* Concurrent provider acceptance tests against different terraform versions
* Install Terraform beforehand, do not delegate Terraform SDK v2 to do download and install Terraform

## Why

* There is an issue caused when parallel Terraform Provider acceptance tests install Terraform at the same time. Explained fairly well in https://github.com/hashicorp/terraform-provider-kubernetes/pull/2256
* Better testing by using different versions of the Terraform binary (3 latest stable minor versions — their latest stable patch version resolved by [terraform-switcher](https://github.com/warrensbox/terraform-switcher) aka `tfswitch`)

## Notes

* Will probably need to test against OpenTofu in the future

## Checklist

* [x] _I have read [CONTRIBUTING.md](https://github.com/codefresh-io/terraform-provider-codefresh/blob/master/CONTRIBUTING.md)._
* [x] _I have [allowed changes to my fork to be made](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)._
* [x] _I have added tests, assuming new tests are warranted_.
* [x] _I understand that the `/test` comment will be ignored by the CI trigger [unless it is made by a repo admin or collaborator](https://codefresh.io/docs/docs/pipelines/triggers/git-triggers/#support-for-building-pull-requests-from-forks)._
