### PR TITLE
Feat: Update supported terraform versions - Minimal version 1.3.0 and Maximum version 1.7.0

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,7 +27,8 @@ steps:
       - TF_ACC="test"
       - CGO_ENABLED=0
     commands:
-      - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh && chmod +x /tmp/tfswitch-install.sh && /tmp/tfswitch-install.sh -b /tmp && /tmp/tfswitch --latest-stable ${TF_VERSION}
+      - go install github.com/warrensbox/terraform-switcher@0.13.1308
+      - terraform-switcher --latest-stable ${TF_VERSION}
       - sleep $((RANDOM % 45))
       - go test -v ./...
     retry:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -30,7 +30,7 @@ steps:
       - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh
       - chmod +x /tmp/tfswitch-install.sh
       - /tmp/tfswitch-install.sh
-      - tfswitch --latest-stable ${TF_VERSION}
+      - /usr/local/bin/tfswitch --latest-stable ${TF_VERSION}
       - sleep $((RANDOM % 45))
       - go test -v ./...
     retry:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,11 +27,11 @@ steps:
       - TF_ACC="test"
       - CGO_ENABLED=0
     commands:
-      - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh
+      - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh && chmod +x /tmp/tfswitch-install.sh && /tmp/tfswitch-install.sh
       - chmod +x /tmp/tfswitch-install.sh
       - /tmp/tfswitch-install.sh
       - ls -ltra /usr/local/bin
-      - /usr/local/bin/tfswitch --latest-stable ${TF_VERSION}
+      - tfswitch --latest-stable ${TF_VERSION}
       - sleep $((RANDOM % 45))
       - go test -v ./...
     retry:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -30,6 +30,7 @@ steps:
       - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh
       - chmod +x /tmp/tfswitch-install.sh
       - /tmp/tfswitch-install.sh
+      - ls -ltra /usr/local/bin
       - /usr/local/bin/tfswitch --latest-stable ${TF_VERSION}
       - sleep $((RANDOM % 45))
       - go test -v ./...

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,8 +27,11 @@ steps:
       - TF_ACC="test"
       - CGO_ENABLED=0
     commands:
-      - go install github.com/warrensbox/terraform-switcher@0.13.1308
-      - terraform-switcher --latest-stable ${TF_VERSION}
+      - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh
+      - chmod +x /tmp/tfswitch-install.sh
+      - /tmp/tfswitch-install.sh
+      - tfswitch --latest-stable ${TF_VERSION}
+      - sleep $((RANDOM % 45))
       - go test -v ./...
     retry:
       maxAttempts: 3
@@ -38,8 +41,7 @@ steps:
       # The following will resolve to their latest patch version
       environment:
         - TF_VERSION=1.3.0
-        - TF_VERSION=1.4.0
-        - TF_VERSION=1.5.0
+        - TF_VERSION=1.7.0
 
   prepare_env_vars:
     title: "Preparing environment variables..."

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,8 +27,7 @@ steps:
       - TF_ACC="test"
       - CGO_ENABLED=0
     commands:
-      - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh && chmod +x /tmp/tfswitch-install.sh && /tmp/tfswitch-install.sh -b /tmp
-      - /tmp/tfswitch --latest-stable ${TF_VERSION}
+      - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh && chmod +x /tmp/tfswitch-install.sh && /tmp/tfswitch-install.sh -b /tmp && /tmp/tfswitch --latest-stable ${TF_VERSION}
       - sleep $((RANDOM % 45))
       - go test -v ./...
     retry:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,11 +27,8 @@ steps:
       - TF_ACC="test"
       - CGO_ENABLED=0
     commands:
-      - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh && chmod +x /tmp/tfswitch-install.sh && /tmp/tfswitch-install.sh
-      - chmod +x /tmp/tfswitch-install.sh
-      - /tmp/tfswitch-install.sh
-      - ls -ltra /usr/local/bin
-      - tfswitch --latest-stable ${TF_VERSION}
+      - wget -O /tmp/tfswitch-install.sh https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh && chmod +x /tmp/tfswitch-install.sh && /tmp/tfswitch-install.sh -b /tmp
+      - /tmp/tfswitch --latest-stable ${TF_VERSION}
       - sleep $((RANDOM % 45))
       - go test -v ./...
     retry:


### PR DESCRIPTION
## What
Update supported terraform versions in CI pipeline
## Why

## Notes
<!-- Add any notes here -->

## Checklist

* [ ] _I have read [CONTRIBUTING.md](https://github.com/codefresh-io/terraform-provider-codefresh/blob/master/CONTRIBUTING.md)._
* [ ] _I have [allowed changes to my fork to be made](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)._
* [ ] _I have added tests, assuming new tests are warranted_.
* [ ] _I understand that the `/test` comment will be ignored by the CI trigger [unless it is made by a repo admin or collaborator](https://codefresh.io/docs/docs/pipelines/triggers/git-triggers/#support-for-building-pull-requests-from-forks)._
