### PR TITLE
Fix -  codefresh_current_account data source returns 403

### DIFF
--- a/codefresh/cfclient/current_account.go
+++ b/codefresh/cfclient/current_account.go
@@ -96,6 +96,7 @@ func (client *Client) GetCurrentAccount() (*CurrentAccount, error) {
 		})
 
 		// If user exists in Admin list append it to addmins as well. This assumes that a user cannot be an admin without being a regular user too.
+		// Which is indeed the case currenty in Codefresh
 		if slices.Contains(accountAdminsIDs, userID) {
 			currentAccount.Admins = append(currentAccount.Admins, CurrentAccountUser{
 				ID:       userID,

--- a/codefresh/cfclient/current_account.go
+++ b/codefresh/cfclient/current_account.go
@@ -3,6 +3,7 @@ package cfclient
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/stretchr/objx"
 )
@@ -50,6 +51,8 @@ func (client *Client) GetCurrentAccount() (*CurrentAccount, error) {
 		Admins: make([]CurrentAccountUser, 0),
 	}
 
+	accountAdminsIDs := make([]string, 0)
+
 	allAccountsI := currentAccountX.Get("account").InterSlice()
 	for _, accI := range allAccountsI {
 		accX := objx.New(accI)
@@ -57,16 +60,7 @@ func (client *Client) GetCurrentAccount() (*CurrentAccount, error) {
 			currentAccount.ID = accX.Get("id").String()
 			admins := accX.Get("admins").InterSlice()
 			for _, adminI := range admins {
-				admin, err := client.GetUserByID(adminI.(string))
-				if err != nil {
-					return nil, err
-				}
-				currentAccount.Admins = append(currentAccount.Admins, CurrentAccountUser{
-					ID:       admin.ID,
-					UserName: admin.UserName,
-					Email:    admin.Email,
-					Status:   admin.Status,
-				})
+				accountAdminsIDs = append(accountAdminsIDs, adminI.(string))
 			}
 			break
 		}
@@ -100,6 +94,16 @@ func (client *Client) GetCurrentAccount() (*CurrentAccount, error) {
 			Email:    email,
 			Status:   status,
 		})
+
+		// If user exists in Admin list append it to addmins as well. This assumes that a user cannot be an admin without being a regular user too
+		if slices.Contains(accountAdminsIDs, userID) {
+			currentAccount.Admins = append(currentAccount.Users, CurrentAccountUser{
+				ID:       userID,
+				UserName: userName,
+				Email:    email,
+				Status:   status,
+			})
+		}
 	}
 
 	return currentAccount, nil

--- a/codefresh/cfclient/current_account.go
+++ b/codefresh/cfclient/current_account.go
@@ -60,7 +60,7 @@ func (client *Client) GetCurrentAccount() (*CurrentAccount, error) {
 			currentAccount.ID = accX.Get("id").String()
 			admins := accX.Get("admins").InterSlice()
 			for _, adminI := range admins {
-				accountAdminsIDs = append(accountAdminsIDs, adminI.(string))
+				accountAdminsIDs = append(accountAdminsIDs ,adminI.(string))
 			}
 			break
 		}
@@ -95,9 +95,9 @@ func (client *Client) GetCurrentAccount() (*CurrentAccount, error) {
 			Status:   status,
 		})
 
-		// If user exists in Admin list append it to addmins as well. This assumes that a user cannot be an admin without being a regular user too
+		// If user exists in Admin list append it to addmins as well. This assumes that a user cannot be an admin without being a regular user too.
 		if slices.Contains(accountAdminsIDs, userID) {
-			currentAccount.Admins = append(currentAccount.Users, CurrentAccountUser{
+			currentAccount.Admins = append(currentAccount.Admins, CurrentAccountUser{
 				ID:       userID,
 				UserName: userName,
 				Email:    email,

--- a/codefresh/resource_project_test.go
+++ b/codefresh/resource_project_test.go
@@ -83,9 +83,9 @@ func TestAccCodefreshProject_Variables(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"encrypted_variables"},
 			},
 			{
@@ -170,7 +170,7 @@ resource "codefresh_project" "test" {
 `, rName, tag1, tag2)
 }
 
-func testAccCodefreshProjectBasicConfigVariables(rName, var1Name, var1Value, var2Name, var2Value, encrytedVar1Name,encrytedVar1Value string) string {
+func testAccCodefreshProjectBasicConfigVariables(rName, var1Name, var1Value, var2Name, var2Value, encrytedVar1Name, encrytedVar1Value string) string {
 	return fmt.Sprintf(`
 resource "codefresh_project" "test" {
   name = "%s"
@@ -183,5 +183,5 @@ resource "codefresh_project" "test" {
 	%q = %q
   }
 }
-`, rName, var1Name, var1Value, var2Name, var2Value, encrytedVar1Name,encrytedVar1Value)
+`, rName, var1Name, var1Value, var2Name, var2Value, encrytedVar1Name, encrytedVar1Value)
 }


### PR DESCRIPTION
## What
Remove unnecessary call to GetUserByID that requires admin token to get the account admins info. Instead infer admin info from /user endpoint which returns the info for all users. As admins are also users the data is there, it is enough to just locate the admins in this existing list. 
## Why
Closes #131 
## Notes
<!-- Add any notes here -->

## Checklist

* [ ] _I have read [CONTRIBUTING.md](https://github.com/codefresh-io/terraform-provider-codefresh/blob/master/CONTRIBUTING.md)._
* [ ] _I have [allowed changes to my fork to be made](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)._
* [ ] _I have added tests, assuming new tests are warranted_.
* [ ] _I understand that the `/test` comment will be ignored by the CI trigger [unless it is made by a repo admin or collaborator](https://codefresh.io/docs/docs/pipelines/triggers/git-triggers/#support-for-building-pull-requests-from-forks)._
