### PR TITLE
fix(resource/pipeline): fix `permit_restart_from_failed_steps = false`

### DIFF
--- a/codefresh/cfclient/pipeline.go
+++ b/codefresh/cfclient/pipeline.go
@@ -133,7 +133,7 @@ type Spec struct {
 	RequiredAvailableStorage     string                   `json:"requiredAvailableStorage,omitempty"`
 	Hooks                        *Hooks                   `json:"hooks,omitempty"`
 	Options                      map[string]bool          `json:"options,omitempty"`
-	PermitRestartFromFailedSteps bool                     `json:"permitRestartFromFailedSteps,omitempty"`
+	PermitRestartFromFailedSteps *bool                    `json:"permitRestartFromFailedSteps,omitempty"`
 	ExternalResources            []ExternalResource       `json:"externalResources,omitempty"`
 }
 

--- a/codefresh/data_current_account_user.go
+++ b/codefresh/data_current_account_user.go
@@ -68,7 +68,6 @@ func mapDataCurrentAccountUserToResource(currentAccount *cfclient.CurrentAccount
 
 	isFound := false
 
-
 	for _, user := range currentAccount.Users {
 		if (userAttributeName == "name" && user.UserName == userAttributeValue) || (userAttributeName == "email" && user.Email == userAttributeValue) {
 			isFound = true

--- a/codefresh/resource_pipeline.go
+++ b/codefresh/resource_pipeline.go
@@ -1117,23 +1117,19 @@ func mapResourceToPipeline(d *schema.ResourceData) (*cfclient.Pipeline, error) {
 		},
 	}
 
-	hasPermitRestartChanged := d.HasChange("spec.0.permit_restart_from_failed_steps")
-	hasPermitRestartUseAccountChanged := d.HasChange("spec.0.permit_restart_from_failed_steps_use_account_settings")
-	if hasPermitRestartChanged || hasPermitRestartUseAccountChanged {
-		shouldPermitRestart := d.Get("spec.0.permit_restart_from_failed_steps").(bool)
-		shouldUseAccountSettings := d.Get("spec.0.permit_restart_from_failed_steps_use_account_settings").(bool)
-		switch shouldUseAccountSettings {
+	shouldPermitRestart := d.Get("spec.0.permit_restart_from_failed_steps").(bool)
+	shouldUseAccountSettings := d.Get("spec.0.permit_restart_from_failed_steps_use_account_settings").(bool)
+	switch shouldUseAccountSettings {
+	case true:
+		pipeline.Spec.PermitRestartFromFailedSteps = nil
+	default:
+		switch shouldPermitRestart {
 		case true:
-			pipeline.Spec.PermitRestartFromFailedSteps = nil
+			pipeline.Spec.PermitRestartFromFailedSteps = ptrBool(true)
+		case false:
+			pipeline.Spec.PermitRestartFromFailedSteps = ptrBool(false)
 		default:
-			switch shouldPermitRestart {
-			case true:
-				pipeline.Spec.PermitRestartFromFailedSteps = ptrBool(true)
-			case false:
-				pipeline.Spec.PermitRestartFromFailedSteps = ptrBool(false)
-			default:
-				pipeline.Spec.PermitRestartFromFailedSteps = nil
-			}
+			pipeline.Spec.PermitRestartFromFailedSteps = nil
 		}
 	}
 

--- a/codefresh/resource_pipeline.go
+++ b/codefresh/resource_pipeline.go
@@ -17,6 +17,10 @@ import (
 
 var terminationPolicyOnCreateBranchAttributes = []string{"branchName", "ignoreTrigger", "ignoreBranch"}
 
+func ptrBool(b bool) *bool {
+	return &b
+}
+
 func resourcePipeline() *schema.Resource {
 	return &schema.Resource{
 		Description: "The central component of the Codefresh Platform. Pipelines are workflows that contain individual steps. Each step is responsible for a specific action in the process.",
@@ -1090,7 +1094,7 @@ func mapResourceToPipeline(d *schema.ResourceData) (*cfclient.Pipeline, error) {
 			Concurrency:                  d.Get("spec.0.concurrency").(int),
 			BranchConcurrency:            d.Get("spec.0.branch_concurrency").(int),
 			TriggerConcurrency:           d.Get("spec.0.trigger_concurrency").(int),
-			PermitRestartFromFailedSteps: d.Get("spec.0.permit_restart_from_failed_steps").(bool),
+			PermitRestartFromFailedSteps: ptrBool(d.Get("spec.0.permit_restart_from_failed_steps").(bool)),
 		},
 	}
 

--- a/codefresh/resource_pipeline_test.go
+++ b/codefresh/resource_pipeline_test.go
@@ -90,10 +90,10 @@ func TestAccCodefreshPipeline_PremitRestartFromFailedSteps(t *testing.T) {
 		CheckDestroy: testAccCheckCodefreshPipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", ptrBool(true)),
+				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", PermitRestartPermit),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", PermitRestartPermit),
 				),
 			},
 			{
@@ -102,10 +102,22 @@ func TestAccCodefreshPipeline_PremitRestartFromFailedSteps(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", ptrBool(false)),
+				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", PermitRestartForbid),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", "false"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", PermitRestartForbid),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", PermitRestartUseAccountSettings),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", PermitRestartUseAccountSettings),
 				),
 			},
 		},
@@ -1070,7 +1082,7 @@ resource "codefresh_pipeline" "test" {
 `, rName, repo, path, revision, context, concurrency, concurrencyBranch, concurrencyTrigger)
 }
 
-func testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(rName string, repo string, path string, revision string, context string, permitRestartFromFailedSteps *bool) string {
+func testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(rName string, repo string, path string, revision string, context string, permitRestartFromFailedSteps string) string {
 	return fmt.Sprintf(`
 resource "codefresh_pipeline" "test" {
 
@@ -1090,11 +1102,11 @@ resource "codefresh_pipeline" "test" {
     	context     = %q
 	}
 
-	permit_restart_from_failed_steps = %t
+	permit_restart_from_failed_steps = %s
 
   }
 }
-`, rName, repo, path, revision, context, *permitRestartFromFailedSteps)
+`, rName, repo, path, revision, context, permitRestartFromFailedSteps)
 }
 
 func testAccCodefreshPipelineBasicConfigTriggers(

--- a/codefresh/resource_pipeline_test.go
+++ b/codefresh/resource_pipeline_test.go
@@ -90,7 +90,7 @@ func TestAccCodefreshPipeline_PremitRestartFromFailedSteps(t *testing.T) {
 		CheckDestroy: testAccCheckCodefreshPipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", true),
+				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", ptrBool(true)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", "true"),
@@ -102,7 +102,7 @@ func TestAccCodefreshPipeline_PremitRestartFromFailedSteps(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", false),
+				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", ptrBool(false)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", "false"),
@@ -1070,7 +1070,7 @@ resource "codefresh_pipeline" "test" {
 `, rName, repo, path, revision, context, concurrency, concurrencyBranch, concurrencyTrigger)
 }
 
-func testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(rName string, repo string, path string, revision string, context string, permitRestartFromFailedSteps bool) string {
+func testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(rName string, repo string, path string, revision string, context string, permitRestartFromFailedSteps *bool) string {
 	return fmt.Sprintf(`
 resource "codefresh_pipeline" "test" {
 
@@ -1094,7 +1094,7 @@ resource "codefresh_pipeline" "test" {
 
   }
 }
-`, rName, repo, path, revision, context, permitRestartFromFailedSteps)
+`, rName, repo, path, revision, context, *permitRestartFromFailedSteps)
 }
 
 func testAccCodefreshPipelineBasicConfigTriggers(

--- a/codefresh/resource_pipeline_test.go
+++ b/codefresh/resource_pipeline_test.go
@@ -90,10 +90,10 @@ func TestAccCodefreshPipeline_PremitRestartFromFailedSteps(t *testing.T) {
 		CheckDestroy: testAccCheckCodefreshPipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", PermitRestartPermit),
+				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", PermitRestartPermit),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", "true"),
 				),
 			},
 			{
@@ -102,22 +102,10 @@ func TestAccCodefreshPipeline_PremitRestartFromFailedSteps(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", PermitRestartForbid),
+				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", PermitRestartForbid),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(name, "codefresh-contrib/react-sample-app", "./codefresh.yml", "master", "git", PermitRestartUseAccountSettings),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCodefreshPipelineExists(resourceName, &pipeline),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", PermitRestartUseAccountSettings),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.permit_restart_from_failed_steps", "false"),
 				),
 			},
 		},
@@ -1082,7 +1070,7 @@ resource "codefresh_pipeline" "test" {
 `, rName, repo, path, revision, context, concurrency, concurrencyBranch, concurrencyTrigger)
 }
 
-func testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(rName string, repo string, path string, revision string, context string, permitRestartFromFailedSteps string) string {
+func testAccCodefreshPipelineBasicConfigPermitRestartFromFailedSteps(rName string, repo string, path string, revision string, context string, permitRestartFromFailedSteps bool) string {
 	return fmt.Sprintf(`
 resource "codefresh_pipeline" "test" {
 
@@ -1102,7 +1090,7 @@ resource "codefresh_pipeline" "test" {
     	context     = %q
 	}
 
-	permit_restart_from_failed_steps = %s
+	permit_restart_from_failed_steps = %t
 
   }
 }

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -132,7 +132,8 @@ Optional:
 - `external_resource` (Block List) (see [below for nested schema](#nestedblock--spec--external_resource))
 - `options` (Block List, Max: 1) The options for the pipeline. (see [below for nested schema](#nestedblock--spec--options))
 - `pack_id` (String) SAAS pack (`5cd1746617313f468d669013` for Small; `5cd1746717313f468d669014` for Medium; `5cd1746817313f468d669015` for Large; `5cd1746817313f468d669017` for XL; `5cd1746817313f468d669018` for XXL); `5cd1746817313f468d669020` for 4XL).
-- `permit_restart_from_failed_steps` (Boolean) Defines whether it is permitted to restart builds in this pipeline from failed step. Defaults to true
+- `permit_restart_from_failed_steps` (Boolean) Defines whether it is permitted to restart builds in this pipeline from failed step (default: `true`).
+- `permit_restart_from_failed_steps_use_account_settings` (Boolean) Defines whether `permit_restart_from_failed_steps` should be set to “Use account settings” (default: `false`). If set, `permit_restart_from_failed_steps` will be ignored.
 - `priority` (Number) Helps to organize the order of builds execution in case of reaching the concurrency limit (default: `0`).
 - `required_available_storage` (String) Minimum disk space required for build filesystem ( unit Gi is required).
 - `runtime_environment` (Block List) The runtime environment for the pipeline. (see [below for nested schema](#nestedblock--spec--runtime_environment))


### PR DESCRIPTION
## What

This fixes `permit_restart_from_failed_steps` behavior in `pipeline` resource.

Before this fix, setting `permit_restart_from_failed_steps = false` or omitting this key resulted in “Permit restart from failed step: Use account settings” for both cases.

New syntax/behavior is:
`permit_restart_from_failed_steps = [true|false]` with the default value `true` (“Permit”).
If `false`, the policy is set to “Forbid”.

New flag is added: `permit_restart_from_failed_steps_use_account_settings = [false|true]` with the default value `false` (“do not use account settings”).
If `true`, `permit_restart_from_failed_steps` will be ignored and pipeline policy will be set to “Use account settings”.


> [!WARNING]
> BREAKING CHANGES!
> * Previously, `permit_restart_from_failed_steps = false` resulted in “Permit restart from failed step: Use account settings”.
> From now on, setting `permit_restart_from_failed_steps = false` will result in “Permit restart from failed step: Forbid”

Fixes #CR-26963

## Notes
<!-- Add any notes here -->

## Checklist

* [x] _I have read [CONTRIBUTING.md](https://github.com/codefresh-io/terraform-provider-codefresh/blob/master/CONTRIBUTING.md)._
* [ ] _I have [allowed changes to my fork to be made](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)._
* [x] _I have added tests, assuming new tests are warranted_.
* [x] _I understand that the `/test` comment will be ignored by the CI trigger [unless it is made by a repo admin or collaborator](https://codefresh.io/docs/docs/pipelines/triggers/git-triggers/#support-for-building-pull-requests-from-forks)._
