### PR TITLE
fix: api key read errors out when getting keys for users

### DIFF
--- a/codefresh/cfclient/api_key.go
+++ b/codefresh/cfclient/api_key.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 )
 
 type ApiKeySubject struct {
@@ -38,14 +36,21 @@ type TokenResponse struct {
 	} `json:"user"`
 }
 
-func (client *Client) GetAPIKey(keyID string) (*ApiKey, error) {
+func (client *Client) GetAPIKey(userID string, accountId string, keyID string) (*ApiKey, error) {
+
+	xAccessToken, err := client.GetXAccessToken(userID, accountId)
+
+	if err != nil {
+		return nil, err
+	}
 
 	opts := RequestOptions{
 		Path:   fmt.Sprintf("/auth/key/%s", keyID),
+		XAccessToken: xAccessToken,
 		Method: "GET",
 	}
 
-	resp, err := client.RequestAPI(&opts)
+	resp, err := client.RequestApiXAccessToken(&opts)
 
 	if err != nil {
 		return nil, err
@@ -61,14 +66,21 @@ func (client *Client) GetAPIKey(keyID string) (*ApiKey, error) {
 	return &apiKey, nil
 }
 
-func (client *Client) DeleteAPIKey(keyID string) error {
+func (client *Client) DeleteAPIKey(userID string, accountId string, keyID string) error {
+	// login as user
 
+	xAccessToken, err := client.GetXAccessToken(userID, accountId)
+
+	if err != nil {
+		return err
+	}
 	opts := RequestOptions{
 		Path:   fmt.Sprintf("/auth/key/%s", keyID),
 		Method: "DELETE",
+		XAccessToken: xAccessToken,
 	}
 
-	resp, err := client.RequestAPI(&opts)
+	resp, err := client.RequestApiXAccessToken(&opts)
 	if err != nil {
 		fmt.Println(string(resp))
 		return err
@@ -77,7 +89,7 @@ func (client *Client) DeleteAPIKey(keyID string) error {
 	return nil
 }
 
-func (client *Client) UpdateAPIKey(key *ApiKey) error {
+func (client *Client) UpdateAPIKey(userID string, accountId string,key *ApiKey) error {
 
 	keyID := key.ID
 	if keyID == "" {
@@ -89,13 +101,23 @@ func (client *Client) UpdateAPIKey(key *ApiKey) error {
 		return err
 	}
 
+	var xAccessToken string
+
+	// login as user
+	xAccessToken, err = client.GetXAccessToken(userID, accountId)
+
+	if err != nil {
+		return err
+	}
+
 	opts := RequestOptions{
 		Path:   fmt.Sprintf("/auth/key/%s", keyID),
 		Method: "PATCH",
+		XAccessToken: xAccessToken,
 		Body:   body,
 	}
 
-	resp, err := client.RequestAPI(&opts)
+	resp, err := client.RequestApiXAccessToken(&opts)
 
 	if err != nil {
 		fmt.Println(string(resp))
@@ -110,6 +132,7 @@ func (client *Client) CreateApiKey(userID string, accountId string, apiKey *ApiK
 
 	// Check collaborataros
 	account, err := client.GetAccountByID(accountId)
+
 	if err != nil {
 		return "", err
 	}
@@ -118,12 +141,7 @@ func (client *Client) CreateApiKey(userID string, accountId string, apiKey *ApiK
 	}
 
 	var xAccessToken string
-	if userID == "" {
-		userID, err = client.createRandomUser(accountId)
-		if err != nil {
-			return "", err
-		}
-	}
+
 	// login as user
 	xAccessToken, err = client.GetXAccessToken(userID, accountId)
 	if err != nil {
@@ -332,32 +350,4 @@ func (client *Client) CreateApiKeyServiceUser(serviceUserId string, apiKey *ApiK
 	}
 
 	return string(resp), nil
-}
-
-func (client *Client) createRandomUser(accountId string) (string, error) {
-	// add user
-	userPrefix := acctest.RandString(10)
-	userName := "tfuser" + userPrefix
-	userEmail := userName + "@codefresh.io"
-
-	user, err := client.AddNewUserToAccount(accountId, userName, userEmail)
-	if err != nil {
-		return "", err
-	}
-	userID := user.ID
-
-	// activate
-	err = client.ActivateUser(userID)
-
-	if err != nil {
-		return "", err
-	}
-
-	// set user as account admin
-	err = client.SetUserAsAccountAdmin(accountId, userID)
-	if err != nil {
-		return "", nil
-	}
-	return userID, nil
-
 }

--- a/codefresh/cfclient/api_key.go
+++ b/codefresh/cfclient/api_key.go
@@ -45,9 +45,9 @@ func (client *Client) GetAPIKey(userID string, accountId string, keyID string) (
 	}
 
 	opts := RequestOptions{
-		Path:   fmt.Sprintf("/auth/key/%s", keyID),
+		Path:         fmt.Sprintf("/auth/key/%s", keyID),
 		XAccessToken: xAccessToken,
-		Method: "GET",
+		Method:       "GET",
 	}
 
 	resp, err := client.RequestApiXAccessToken(&opts)
@@ -75,8 +75,8 @@ func (client *Client) DeleteAPIKey(userID string, accountId string, keyID string
 		return err
 	}
 	opts := RequestOptions{
-		Path:   fmt.Sprintf("/auth/key/%s", keyID),
-		Method: "DELETE",
+		Path:         fmt.Sprintf("/auth/key/%s", keyID),
+		Method:       "DELETE",
 		XAccessToken: xAccessToken,
 	}
 
@@ -89,7 +89,7 @@ func (client *Client) DeleteAPIKey(userID string, accountId string, keyID string
 	return nil
 }
 
-func (client *Client) UpdateAPIKey(userID string, accountId string,key *ApiKey) error {
+func (client *Client) UpdateAPIKey(userID string, accountId string, key *ApiKey) error {
 
 	keyID := key.ID
 	if keyID == "" {
@@ -111,10 +111,10 @@ func (client *Client) UpdateAPIKey(userID string, accountId string,key *ApiKey) 
 	}
 
 	opts := RequestOptions{
-		Path:   fmt.Sprintf("/auth/key/%s", keyID),
-		Method: "PATCH",
+		Path:         fmt.Sprintf("/auth/key/%s", keyID),
+		Method:       "PATCH",
 		XAccessToken: xAccessToken,
-		Body:   body,
+		Body:         body,
 	}
 
 	resp, err := client.RequestApiXAccessToken(&opts)

--- a/codefresh/resource_api_key.go
+++ b/codefresh/resource_api_key.go
@@ -148,7 +148,9 @@ func resourceApiKeyRead(d *schema.ResourceData, meta interface{}) error {
 	if serviceAccountId := d.Get("service_account_id").(string); serviceAccountId != "" {
 		apiKey, err = client.GetAPIKeyServiceUser(keyID, serviceAccountId)
 	} else {
-		apiKey, err = client.GetAPIKey(keyID)
+		accountID := d.Get("account_id").(string)
+		userID := d.Get("user_id").(string)
+		apiKey, err = client.GetAPIKey(userID, accountID, keyID)
 	}
 
 	if err != nil {
@@ -178,8 +180,9 @@ func resourceApiKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 	if serviceAccountId := d.Get("service_account_id").(string); serviceAccountId != "" {
 		err = client.UpdateAPIKeyServiceUser(&apiKey, serviceAccountId)
 	} else {
-		err = client.UpdateAPIKey(&apiKey)
-
+		accountID := d.Get("account_id").(string)
+		userID := d.Get("user_id").(string)
+		err = client.UpdateAPIKey(userID, accountID, &apiKey)
 	}
 
 	if err != nil {
@@ -201,7 +204,9 @@ func resourceApiKeyDelete(d *schema.ResourceData, meta interface{}) error {
 	if serviceAccountId := d.Get("service_account_id").(string); serviceAccountId != "" {
 		err = client.DeleteAPIKeyServiceUser(d.Id(), serviceAccountId)
 	} else {
-		err = client.DeleteAPIKey(d.Id())
+		accountID := d.Get("account_id").(string)
+		userID := d.Get("user_id").(string)
+		err = client.DeleteAPIKey(userID, accountID, d.Id())
 	}
 
 	if err != nil {


### PR DESCRIPTION
## What
Fix codefresh_api_key resource - failing with error because of an API behaviour change


## Why

When refreshing state that includes an API key the following error appeared 
<img width="671" height="152" alt="image" src="https://github.com/user-attachments/assets/ddf726fd-1616-48b7-9d11-13caed9e4a4b" />

This is due to the fact the the token request was run without impersonation. Previously this used to return the proper token, but this is not the correct behavior. Because tokens are user and account scoped a switched must be made to the correct user before reading the token. This PR fixes this on the provider and does the switch the correct user before reading the token.


## Notes
<!-- Add any notes here -->

## Checklist

* [ ] _I have read [CONTRIBUTING.md](https://github.com/codefresh-io/terraform-provider-codefresh/blob/master/CONTRIBUTING.md)._
* [ ] _I have [allowed changes to my fork to be made](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)._
* [ ] _I have added tests, assuming new tests are warranted_.
* [ ] _I understand that the `/test` comment will be ignored by the CI trigger [unless it is made by a repo admin or collaborator](https://codefresh.io/docs/docs/pipelines/triggers/git-triggers/#support-for-building-pull-requests-from-forks)._
